### PR TITLE
Fixed Event Log Name

### DIFF
--- a/Alert Toolkit/DefaultAlertConfig.json
+++ b/Alert Toolkit/DefaultAlertConfig.json
@@ -1425,7 +1425,7 @@
       "Information": true
     },
     {
-      "EventLogName": "Microsoft-Windows-NetworkProfile/Operationa",
+      "EventLogName": "Microsoft-Windows-NetworkProfile/Operational",
       "Error": true,
       "Warning": true,
       "Information": true


### PR DESCRIPTION
One of the event logs had the wrong name and was misspelled. Added the missing "L"